### PR TITLE
fix: common mistranscriptions for kde connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ dmypy.json
 .pyre/
 .pytype/
 cython_debug/
+.DS_Store

--- a/skill.json
+++ b/skill.json
@@ -1,6 +1,6 @@
 {
     "title": "",
-    "url": "https://github.com/mikejgray/skill-mark2-audio-receiver",
+    "url": "https://github.com/NeonGeckoCom/skill-mark2-audio-receiver",
     "summary": "",
     "short_description": null,
     "description": "This skill enables voice intents for the following audio receiver options on the Mycroft Mark 2 device: - Airplay (via [UxPlay](https://github.com/FDH2/UxPlay)) - [KDE Connect](https://kdeconnect.kde.org/) - Spotify (via [Raspotify](https://dtcooper.github.io/raspotify/)) - Bluetooth It allows you to: - Get the status of any of these services on the Mark 2 - Enable/disable the services - Rename your devices in Airplay/Raspotify - Pair Bluetooth/KDE Connect with other devices Supported in Neon versions after mid-August (TODO: Specific version when it's available) Requires [neon-phal-plugin-audio-receiver](), an admin PHAL plugin that handles the portions of the code that require `sudo`.",
@@ -53,6 +53,6 @@
         "Gray"
     ],
     "skillname": "skill-mark2-audio-receiver",
-    "authorname": "mikejgray",
+    "authorname": "NeonGeckoCom",
     "foldername": null
 }

--- a/skill_markII_audio_receiver/locale/en-us/intents/enable-kde-connect.intent
+++ b/skill_markII_audio_receiver/locale/en-us/intents/enable-kde-connect.intent
@@ -1,2 +1,2 @@
-enable (kde connect|kay dee ee connect|k.d.e. connect)
-activate (kde connect|kay dee ee connect|k.d.e. connect)
+enable (kde connect|kay dee ee connect|k.d.e. connect|katie econnect|katie connect|kdee connect|a d e connect|kd econnect)
+activate (kde connect|kay dee ee connect|k.d.e. connect|katie econnect|katie connect|kdee connect|a d e connect|kd econnect)

--- a/skill_markII_audio_receiver/locale/en-us/intents/pair-kde-connect.intent
+++ b/skill_markII_audio_receiver/locale/en-us/intents/pair-kde-connect.intent
@@ -1,5 +1,2 @@
-(air|hair|pair|pare|pear) kde connect
-(air|hair|pair|pare|pear) kay dee ee connect
-start (pairing|paring) kde connect
-start (pairing|paring) kay dee ee connect
-start (pairing|paring) k.d.e. connect
+(are|air|hair|pair|pare|pear) (kde connect|kay dee ee connect|katie econnect|katie connect|kdee connect|a d e connect|kd econnect)
+start (pairing|paring) (kde connect|kay dee ee connect|katie econnect|katie connect|kdee connect|a d e connect|kd econnect)


### PR DESCRIPTION
# Description
Add some commonly mistranscribed utterances from Neon's default STT.

# Issues
Closes #5 
